### PR TITLE
Fix typo in checkout command (missing space)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ For more information, please refer to [GitHub's instructions on this](https://he
 
 To submit changes:
  * Make sure your local copy is updated.
- * Create a dedicated branch locally (`git checkout-b <nombre-de-la-rama>`).
+ * Create a dedicated branch locally (`git checkout -b <nombre-de-la-rama>`).
  * Add your changes by creating [_micro commits_](https://lucasr.org/2011/01/29/micro-commits/).
  * Once your changes are completed, push them to your fork.
  * Finally, create a [GitHub Pull Request](https://help.github.com/articles/creating-a-pull-request-from-a-fork/) from your fork, by using GitHub's web interface.

--- a/changelog.md
+++ b/changelog.md
@@ -28,7 +28,7 @@ This file keeps a log of version releases. This file is maintained
 
 * Minor fix: replaced ']' by ')' in reference link in the principles section
 * Rephrasing "control structures" entry
-* Minor improvements to changelog
+* Minor improvements to changelog and typo fixed in contributing guideline
 
 #### Removed
 


### PR DESCRIPTION
Missing space between "checkout" and the "-b" option.

### Submitter checklist

- [X] Make sure your branch is updated
- [X] Read and follow the CONTRIBUTING file
- [X] Update the changelog file (if applicable)
